### PR TITLE
Include line in review comment API calls

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGroovyObject.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGroovyObject.java
@@ -595,16 +595,17 @@ public class PullRequestGroovyObject extends GroovyObjectSupport implements Seri
     @Whitelisted
     public ReviewCommentGroovyObject reviewComment(final String commitId,
                                                    final String path,
-                                                   final int position,
+                                                   final int line,
                                                    final String body) {
         Objects.requireNonNull(commitId, "commitId is a required argument");
         Objects.requireNonNull(path, "path is a required argument");
+        Objects.requireNonNull(line, "line is a required argument");
         Objects.requireNonNull(body, "body is a required argument");
 
         ExtendedCommitComment comment = new ExtendedCommitComment();
         comment.setCommitId(commitId);
         comment.setPath(path);
-        comment.setPosition(position);
+        comment.setLine(line);
         comment.setBody(body);
         try {
             return new ReviewCommentGroovyObject(


### PR DESCRIPTION
This change sets `line` instead of `position` when adding review comments through `pullRequest.reviewComment(...)` to not have the API call fail with an error.

Seems like GitHub made a change to their API, or I assume this code at one point worked at least, there's an issue upstream about this: https://github.com/jenkinsci/pipeline-github-plugin/issues/88.

🦐 